### PR TITLE
Updated ResNets for CIFAR-10

### DIFF
--- a/models/densenetsCIFAR10.py
+++ b/models/densenetsCIFAR10.py
@@ -1,0 +1,212 @@
+"""
+@Title: DenseNets on PyTorch for CIFAR-10
+
+@References:
+
+[1] Gao Huang, Zhuang Liu, Laurens van der Maaten
+    Densely Connected Deep Convolutional Networks. arXiv:1512.03385
+    
+[2] PyTorch Open Source Repository
+    https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py   
+"""
+
+
+import math
+import torch
+import torch.nn as nn
+
+
+class SingleLayer(nn.Module):
+    
+    def __init__(self, nChannels, growthRate):
+        super(SingleLayer, self).__init__()
+        
+        self.bn1 = nn.BatchNorm2d(nChannels)
+        self.conv1 = nn.Conv2d(nChannels, growthRate, kernel_size=3, padding=1, bias=False)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        out = self.conv1(self.relu(self.bn1(x)))
+        out = torch.cat((x, out), 1)
+        return out
+
+
+
+class Bottleneck(nn.Module):
+    
+    def __init__(self, nChannels, growthRate):
+        super(Bottleneck, self).__init__()
+        
+        self.bn1 = nn.BatchNorm2d(nChannels)
+        self.conv1 = nn.Conv2d(nChannels, 4*growthRate, kernel_size=1, bias=False)
+        
+        self.bn2 = nn.BatchNorm2d(4*growthRate)
+        self.conv2 = nn.Conv2d(4*growthRate, growthRate, kernel_size=3, padding=1, bias=False)
+        
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        out = self.conv1(self.relu(self.bn1(x)))
+        out = self.conv2(self.relu(self.bn2(out)))
+        out = torch.cat((x, out), 1)
+        return out
+
+
+class Transition(nn.Module):
+    
+    def __init__(self, nChannels, nOutChannels):
+        super(Transition, self).__init__()
+        
+        self.bn1 = nn.BatchNorm2d(nChannels)
+        self.conv1 = nn.Conv2d(nChannels, nOutChannels, kernel_size=1, bias=False)
+        self.avgpool = nn.AvgPool2d(kernel_size=2)
+
+    def forward(self, x):
+        out = self.conv1(self.relu(self.bn1(x)))
+        out = self.avgpool(out)
+        return out
+
+
+class DenseNet(nn.Module):
+    
+    def __init__(self, growthRate, depth, reduction, nClasses, bottleneck):
+        super(DenseNet, self).__init__()
+        
+        compression = True if reduction < 1 else False  # Determine if DenseNet-C
+        
+        nDenseBlocks = (depth-4) // 3
+        if bottleneck:
+            nDenseBlocks //= 2
+            
+        nChannels = 2 * growthRate if compression and bottleneck else 16
+        
+        # First convolution
+        self.conv1 = nn.Conv2d(3, nChannels, kernel_size=3, padding=1, bias=False)
+        
+        # Dense Block 1 
+        self.dense1 = self._make_dense(nChannels, growthRate, nDenseBlocks, bottleneck)
+        nChannels += nDenseBlocks*growthRate
+        nOutChannels = int(math.floor(nChannels*reduction))
+        
+        # Transition Block 1
+        self.trans1 = Transition(nChannels, nOutChannels)
+        nChannels = nOutChannels
+        
+        # Dense Block 2
+        self.dense2 = self._make_dense(nChannels, growthRate, nDenseBlocks, bottleneck)
+        nChannels += nDenseBlocks*growthRate
+        nOutChannels = int(math.floor(nChannels*reduction))
+        
+        # Transition Block 2
+        self.trans2 = Transition(nChannels, nOutChannels)
+        nChannels = nOutChannels
+        
+        # Dense Block 3
+        self.dense3 = self._make_dense(nChannels, growthRate, nDenseBlocks, bottleneck)
+        
+        # Transition Block 3
+        nChannels += nDenseBlocks*growthRate
+        self.bn1 = nn.BatchNorm2d(nChannels)
+        
+        # Dense Layer
+        self.avgpool = nn.AvgPool2d(kernel_size=8)
+        def flatten(x): return x.view(x.size(0), -1)
+        self.fc = nn.Linear(nChannels, nClasses)
+        
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+                m.weight.data.normal_(0, math.sqrt(2. / n))
+            elif isinstance(m, nn.BatchNorm2d):
+                m.weight.data.fill_(1)
+                m.bias.data.zero_()
+            elif isinstance(m, nn.Linear):
+                m.bias.data.zero_()
+
+    def _make_dense(self, nChannels, growthRate, nDenseBlocks, bottleneck):
+        ''' Function to build a Dense Block '''
+        layers = []
+        for i in range(int(nDenseBlocks)):
+            if bottleneck:
+                layers.append(Bottleneck(nChannels, growthRate))
+            else:
+                layers.append(SingleLayer(nChannels, growthRate))
+            nChannels += growthRate
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = self.conv1(x)                     # 32x32
+        out = self.trans1(self.dense1(out))     # 16x16
+        out = self.trans2(self.dense2(out))     # 8x8
+        out = self.dense3(out)                  # 8x8
+        out = self.avgpool(out)                 # 1x1
+        out = self.flatten(out)
+        out = self.fc(out)
+        return out
+
+
+
+def denseNet_40_12():
+    return DenseNet(12, 40, 1, 10, bottleneck=False)
+
+def denseNet_100_12():
+    return DenseNet(12, 100, 1, 10, bottleneck=False)
+
+def denseNet_100_24():
+    return DenseNet(24, 100, 1, 10, bottleneck=False)
+
+def denseNetBC_100_12():
+    return DenseNet(12, 100, 0.5, 10, bottleneck=True)
+
+def denseNetBC_250_24():
+    return DenseNet(24, 250, 0.5, 10, bottleneck=True)
+
+def denseNetBC_190_40():
+    return DenseNet(40, 190, 0.5, 10, bottleneck=True)
+
+
+
+if __name__ == '__main__':
+
+    from utils import count_parameters
+    from beautifultable import BeautifulTable as BT
+
+    densenet_40_12 = denseNet_40_12()
+    densenet_100_12 = denseNet_100_12()
+    densenet_100_24 = denseNet_100_24()
+    densenetBC_100_12 = denseNetBC_100_12() 
+    densenetBC_250_24 = denseNetBC_250_24()
+    densenetBC_190_40 = denseNetBC_190_40()
+    
+    
+    table = BT()
+    table.append_row(['Model', 'Growth Rate', 'Depth', 'M. of Params'])
+    table.append_row(['DenseNet', 12, 40, count_parameters(densenet_40_12)*1e-6])
+    table.append_row(['DenseNet', 12, 100, count_parameters(densenet_100_12)*1e-6])
+    table.append_row(['DenseNet', 24, 100, count_parameters(densenet_100_24)*1e-6])
+    table.append_row(['DenseNet-BC', 12, 100, count_parameters(densenetBC_100_12)*1e-6])
+    table.append_row(['DenseNet-BC', 24, 250, count_parameters(densenetBC_250_24)*1e-6])
+    table.append_row(['DenseNet-BC', 40, 190, count_parameters(densenetBC_190_40)*1e-6])
+    print(table)
+        
+    
+    '''
+    DenseNets implemented on the paper <https://arxiv.org/pdf/1608.06993.pdf>
+    
+    +-------------+-------------+-------+--------------+
+    |    Model    | Growth Rate | Depth | M. of Params |
+    +-------------+-------------+-------+--------------+
+    |  DenseNet   |     12      |  40   |     1.02     |
+    +-------------+-------------+-------+--------------+
+    |  DenseNet   |     12      |  100  |     6.98     |
+    +-------------+-------------+-------+--------------+
+    |  DenseNet   |     24      |  100  |    27.249    |
+    +-------------+-------------+-------+--------------+
+    | DenseNet-BC |     12      |  100  |    0.769     |
+    +-------------+-------------+-------+--------------+
+    | DenseNet-BC |     24      |  250  |    15.324    |
+    +-------------+-------------+-------+--------------+
+    | DenseNet-BC |     40      |  190  |    25.624    |
+    +-------------+-------------+-------+--------------+
+    
+    '''

--- a/models/densenetsCIFAR10.py
+++ b/models/densenetsCIFAR10.py
@@ -74,9 +74,9 @@ class DenseNet(nn.Module):
         
         compression = True if reduction < 1 else False  # Determine if DenseNet-C
         
-        nDenseBlocks = (depth-4) // 3
+        nDenseLayers = (depth-4) // 3
         if bottleneck:
-            nDenseBlocks //= 2
+            nDenseLayers //= 2
             
         nChannels = 2 * growthRate if compression and bottleneck else 16
         
@@ -84,8 +84,8 @@ class DenseNet(nn.Module):
         self.conv1 = nn.Conv2d(3, nChannels, kernel_size=3, padding=1, bias=False)
         
         # Dense Block 1 
-        self.dense1 = self._make_dense(nChannels, growthRate, nDenseBlocks, bottleneck)
-        nChannels += nDenseBlocks*growthRate
+        self.dense1 = self._make_dense(nChannels, growthRate, nDenseLayers, bottleneck)
+        nChannels += nDenseLayers*growthRate
         nOutChannels = int(math.floor(nChannels*reduction))
         
         # Transition Block 1
@@ -93,8 +93,8 @@ class DenseNet(nn.Module):
         nChannels = nOutChannels
         
         # Dense Block 2
-        self.dense2 = self._make_dense(nChannels, growthRate, nDenseBlocks, bottleneck)
-        nChannels += nDenseBlocks*growthRate
+        self.dense2 = self._make_dense(nChannels, growthRate, nDenseLayers, bottleneck)
+        nChannels += nDenseLayers*growthRate
         nOutChannels = int(math.floor(nChannels*reduction))
         
         # Transition Block 2
@@ -102,10 +102,10 @@ class DenseNet(nn.Module):
         nChannels = nOutChannels
         
         # Dense Block 3
-        self.dense3 = self._make_dense(nChannels, growthRate, nDenseBlocks, bottleneck)
+        self.dense3 = self._make_dense(nChannels, growthRate, nDenseLayers, bottleneck)
         
         # Transition Block 3
-        nChannels += nDenseBlocks*growthRate
+        nChannels += nDenseLayers*growthRate
         self.bn1 = nn.BatchNorm2d(nChannels)
         
         # Dense Layer
@@ -123,10 +123,10 @@ class DenseNet(nn.Module):
             elif isinstance(m, nn.Linear):
                 m.bias.data.zero_()
 
-    def _make_dense(self, nChannels, growthRate, nDenseBlocks, bottleneck):
+    def _make_dense(self, nChannels, growthRate, nDenseLayers, bottleneck):
         ''' Function to build a Dense Block '''
         layers = []
-        for i in range(int(nDenseBlocks)):
+        for i in range(int(nDenseLayers)):
             if bottleneck:
                 layers.append(Bottleneck(nChannels, growthRate))
             else:

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -7,6 +7,7 @@ BasicBlock and Bottleneck module is from the original ResNet paper:
 PreActBlock and PreActBottleneck module is from the later paper:
 [2] Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
     Identity Mappings in Deep Residual Networks. arXiv:1603.05027
+    
 '''
 import torch
 import torch.nn as nn
@@ -22,25 +23,31 @@ def conv3x3(in_planes, out_planes, stride=1):
 class BasicBlock(nn.Module):
     expansion = 1
 
-    def __init__(self, in_planes, planes, stride=1):
+    def __init__(self, in_planes, planes, stride=1, downsample=None):
         super(BasicBlock, self).__init__()
+        
         self.conv1 = conv3x3(in_planes, planes, stride)
-        self.bn1 = nn.BatchNorm2d(planes)
         self.conv2 = conv3x3(planes, planes)
+        
+        self.bn1 = nn.BatchNorm2d(planes)
         self.bn2 = nn.BatchNorm2d(planes)
-
-        self.shortcut = nn.Sequential()
-        if stride != 1 or in_planes != self.expansion*planes:
-            self.shortcut = nn.Sequential(
-                nn.Conv2d(in_planes, self.expansion*planes, kernel_size=1, stride=stride, bias=False),
-                nn.BatchNorm2d(self.expansion*planes)
-            )
-
+        
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        
+        self.stride = stride
+        
     def forward(self, x):
-        out = F.relu(self.bn1(self.conv1(x)))
+        
+        residue = x
+        out = self.relu(self.bn1(self.conv1(x)))
         out = self.bn2(self.conv2(out))
-        out += self.shortcut(x)
-        out = F.relu(out)
+        
+        if self.downsample is not None:
+            residue = self.downsample(x)
+            
+        out += residue
+        out = self.relu(out)
         return out
 
 
@@ -128,65 +135,84 @@ class PreActBottleneck(nn.Module):
 
 
 class ResNet(nn.Module):
-    def __init__(self, block, num_blocks, num_classes=10):
+    def __init__(self, depth, name, num_classes=10):
         super(ResNet, self).__init__()
-        self.in_planes = 64
+        
+        assert (depth - 2) % 6 == 0, 'Depth should be 6n + 2'
+        n = (depth - 2) // 6
 
-        self.conv1 = conv3x3(3,64)
-        self.bn1 = nn.BatchNorm2d(64)
-        self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
-        self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, num_blocks[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, num_blocks[3], stride=2)
-        self.linear = nn.Linear(512*block.expansion, num_classes)
+        self.name = name
+        block = BasicBlock
+        self.inplanes = 16
+        fmaps = [16, 32, 64] # CIFAR10        
+        
+        self.conv = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(16)
+        self.relu = nn.ReLU(inplace=True)
+        
+        self.layer1 = self._make_layer(block, fmaps[0], n, stride=1) 
+        self.layer2 = self._make_layer(block, fmaps[1], n, stride=2) 
+        self.layer3 = self._make_layer(block, fmaps[2], n, stride=2) 
+        
+        self.avgpool = nn.AvgPool2d(kernel_size=8, stride=1)                   
+        self.fc = nn.Linear(fmaps[2] * block.expansion, num_classes) 
+        
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
 
-    def _make_layer(self, block, planes, num_blocks, stride):
-        strides = [stride] + [1]*(num_blocks-1)
+    def _make_layer(self, block, planes, blocks, stride=1):        
+        ''' Between layers convolve input to match dimensions -> stride = 2 '''
+        
+        downsample = None
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                    nn.Conv2d(self.inplanes, planes * block.expansion, 
+                              kernel_size=1, stride=stride, bias=False),
+                    nn.BatchNorm2d(planes * block.expansion))
+                
         layers = []
-        for stride in strides:
-            layers.append(block(self.in_planes, planes, stride))
-            self.in_planes = planes * block.expansion
+        layers.append(block(self.inplanes, planes, stride, downsample))
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(block(self.inplanes, planes))
+           
         return nn.Sequential(*layers)
 
-    def forward(self, x, lin=0, lout=5):
-        out = x
-        if lin < 1 and lout > -1:
-            out = self.conv1(out)
-            out = self.bn1(out)
-            out = F.relu(out)
-        if lin < 2 and lout > 0:
-            out = self.layer1(out)
-        if lin < 3 and lout > 1:
-            out = self.layer2(out)
-        if lin < 4 and lout > 2:
-            out = self.layer3(out)
-        if lin < 5 and lout > 3:
-            out = self.layer4(out)
-        if lout > 4:
-            out = F.avg_pool2d(out, 4)
-            out = out.view(out.size(0), -1)
-            out = self.linear(out)
-        return out
+    def forward(self, x):
+        
+        x = self.relu(self.bn(self.conv(x)))    # 32x32
+        x = self.layer1(x)                      # 32x32
+        x = self.layer2(x)                      # 16x16
+        x = self.layer3(x)                      # 8x8
 
+        x = self.avgpool(x)                     # 1x1
+        x = x.view(x.size(0), -1)               # Flatten
+        x  = self.fc(x)                         # Dense
+        return x
 
-def ResNet18():
-    return ResNet(PreActBlock, [2,2,2,2])
+def ResNet20(**kwargs):    
+    return ResNet(name = 'ResNet20', depth = 20, **kwargs)
 
-def ResNet34():
-    return ResNet(BasicBlock, [3,4,6,3])
+def ResNet32(**kwargs):    
+    return ResNet(name = 'ResNet32', depth = 32, **kwargs)
 
-def ResNet50():
-    return ResNet(Bottleneck, [3,4,6,3])
+def ResNet44(**kwargs):    
+    return ResNet(name = 'ResNet44',depth = 44, **kwargs)
 
-def ResNet101():
-    return ResNet(Bottleneck, [3,4,23,3])
+def ResNet56(**kwargs):    
+    return ResNet(name = 'ResNet56',depth = 56, **kwargs)
 
-def ResNet152():
-    return ResNet(Bottleneck, [3,8,36,3])
+def ResNet110(**kwargs):    
+    return ResNet(name = 'ResNet110',depth = 110, **kwargs)
+
 
 
 def test():
-    net = ResNet18()
+    net = ResNet20()
     y = net(Variable(torch.randn(1,3,32,32)))
     print(y.size())
 

--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,6 @@ import torch
 import torch.nn as nn
 import torch.nn.init as init
 
-
 def get_mean_and_std(dataset):
     '''Compute the mean and std value of dataset.'''
     dataloader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=True, num_workers=2)
@@ -123,3 +122,8 @@ def format_time(seconds):
     if f == '':
         f = '0ms'
     return f
+
+
+def count_parameters(model):
+    ''' Count the parameters of a model '''
+    return sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
The ResNets on the folder do not match the architectures described by the authors in the mentioned paper.

Authors only use 3 layers for ResNets on CIFAR-10, and not 4.
Also, there are no ResNet18, ResNet34... and so on for CIFAR-10. Insetead, there are ResNet20, ResNet32, ResNet44, ResNet56, ResNet110.

Here is a documentation I prepared for myself to understand the architecture:
Only theory: http://pabloruizruiz10.com/resources/CNNs/ResNet-on-CIFAR10.pdf
PyTorch implementation: http://pabloruizruiz10.com/resources/CNNs/ResNet-PyTorch.html