### PR TITLE
fix 0 percent training accuracy

### DIFF
--- a/train.py
+++ b/train.py
@@ -158,8 +158,8 @@ def train(epoch):
         train_loss += loss.data[0]
         _, predicted = torch.max(outputs.data, 1)
         total += targets.size(0)
-        correct += (lam * predicted.eq(targets_a.data).cpu().sum()
-                    + (1 - lam) * predicted.eq(targets_b.data).cpu().sum())
+        correct += (lam * predicted.eq(targets_a.data).cpu().sum().float()
+                    + (1 - lam) * predicted.eq(targets_b.data).cpu().sum().float())
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
I'm using Pytorch 0.4.1, python 3.6.6

seems like training accuracy is 0%. I found the reason is that at around line 161

`        correct += (lam * predicted.eq(targets_a.data).cpu().sum()
                    + (1 - lam) * predicted.eq(targets_b.data).cpu().sum())
`

`lam` is a float and `predicted.eq(targets_a.data).cpu().sum()` is an integer tensor and the result is 0 no matter what values they take. After I cast to float, the training accuracy seems to be back to normal. 
